### PR TITLE
linguist ignore massive notebook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 backend/app/shreyas/tonsil_detector.h5 filter=lfs diff=lfs merge=lfs -text
-backend/app/lanre/model_notebooks/* linguist-vendored
+backend/app/lanre/model_notebooks/dipstick_model_v12.ipynb -linguist-vendored


### PR DESCRIPTION
should remove repository language tracking for .ipynb which isn't *really* part of our application and is out of proportion to raw code files so messes up the language statistics on github. 